### PR TITLE
Better signature validation for subkeys.

### DIFF
--- a/git-remote-gcrypt
+++ b/git-remote-gcrypt
@@ -388,7 +388,7 @@ make_new_repo()
 # $1 return var for goodsig match, $2 return var for signers text
 read_config()
 {
-	local recp_= r_keyinfo= cap_= conf_part= good_sig= signers_=
+	local recp_= r_keyinfo= r_keyfpr= gpg_list= cap_= conf_part= good_sig= signers_=
 	Conf_signkey=$(git config --path user.signingkey || :)
 	conf_part=$(git config --get "remote.$NAME.gcrypt-participants" '.+' ||
 		    git config --get gcrypt.participants '.+' || :)
@@ -406,16 +406,21 @@ read_config()
 
 	for recp_ in $conf_part
 	do
-		filter_to @r_keyinfo "pub*" \
-			"$(gpg --with-colons --fast-list -k "$recp_")"
+		gpg_list=$(gpg --with-colons --fast-list --fingerprint -k "$recp_")
+		filter_to @r_keyinfo "pub*" "$gpg_list"
+		filter_to @r_keyfpr "fpr*" "$gpg_list"
 		isnull "$r_keyinfo" || isnonnull "${r_keyinfo##*"$Newline"*}" ||
 		echo_info "WARNING: '$recp_' matches multiple keys, using one"
+		isnull "$r_keyfpr" || isnonnull "${r_keyfpr##*"$Newline"*}" ||
+		echo_info "WARNING: '$recp_' matches multiple fingerprints, using one"
 		r_keyinfo=${r_keyinfo%%"$Newline"*}
+		r_keyfpr=${r_keyfpr%%"$Newline"*}
 		keyid_=$(xfeed "$r_keyinfo" cut -f 5 -d :)
+		fprid_=$(xfeed "$r_keyfpr" cut -f 10 -d :)
 
-		isnonnull "$keyid_" &&
+		isnonnull "$fprid_" &&
 		signers_="$signers_ $keyid_" &&
-		append_to @good_sig "^\[GNUPG:\] GOODSIG $keyid_" || {
+		append_to @good_sig "^\[GNUPG:\] VALIDSIG .*$fprid_$" || {
 			echo_info "WARNING: Skipping missing key $recp_"
 			continue
 		}


### PR DESCRIPTION
I have subkeys that do my signatures however when I set my .git/config gcrypt-participants to the id of the main key, the signing subkey is used when pushing to the repo but when fetching, it fails because it's looking for the main key id. Change the system to validate this by using PGP's [VALIDSIG](https://github.com/gdb/gnupg/blob/gdb/doc/DETAILS#L232) keyword. See [this](http://superuser.com/questions/497940/script-to-verify-a-signature-with-gpg) stackoverflow article for more.

See my example output for what I mean.

``` shell
[root@localhost repo]# gpg --edit-key 477E48E6
gpg (GnuPG) 2.0.14; Copyright (C) 2009 Free Software Foundation, Inc.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Secret key is available.

pub  1024R/477E48E6  created: 2013-09-19  expires: 2018-09-18  usage: C
                     trust: ultimate      validity: ultimate
sub  1024R/69A0DB38  created: 2013-09-19  expires: 2014-09-19  usage: S
sub  1024R/D7A9D563  created: 2013-09-19  expires: 2014-09-19  usage: E
[ultimate] (1). testing <testing@test.com>

[root@localhost repo]# gpg -K
/root/.gnupg/secring.gpg
------------------------
sec   1024R/477E48E6 2013-09-19 [expires: 2018-09-18]
uid                  testing <testing@test.com>
ssb   1024R/69A0DB38 2013-09-19
ssb   1024R/D7A9D563 2013-09-19
[root@localhost repo]# git fetch crypted
gcrypt: Development version -- Repository format MAY CHANGE
gcrypt: Decrypting manifest
gpg: anonymous recipient; trying secret key 477E48E6 ...
gpg: anonymous recipient; trying secret key 69A0DB38 ...
gpg: anonymous recipient; trying secret key D7A9D563 ...
gpg: okay, we are the anonymous recipient.
gpg: Signature made Thu 19 Sep 2013 06:36:05 AM UTC using RSA key ID 69A0DB38
gpg: Good signature from "testing <testing@test.com>"

##### This is where I add         gcrypt-participants = 477E48E6 to the .git/config "crypted" remote

[root@localhost repo]# git fetch crypted
gcrypt: Development version -- Repository format MAY CHANGE
gcrypt: Decrypting manifest
gpg: anonymous recipient; trying secret key 477E48E6 ...
gpg: anonymous recipient; trying secret key 69A0DB38 ...
gpg: anonymous recipient; trying secret key D7A9D563 ...
gpg: okay, we are the anonymous recipient.
gpg: Signature made Thu 19 Sep 2013 06:36:05 AM UTC using RSA key ID 69A0DB38
gpg: Good signature from "testing <testing@test.com>"
gcrypt: Failed to verify manifest signature!
gcrypt: Only accepting signatories:  5BDC6F31477E48E6
gcrypt: Failed to decrypt manifest!

##### This is where I apply the patch in this PR.

[root@localhost repo]# git fetch crypted
gcrypt: Development version -- Repository format MAY CHANGE
gcrypt: Decrypting manifest
gpg: anonymous recipient; trying secret key 477E48E6 ...
can't connect to `/root/.gnupg/S.gpg-agent': No such file or directory
1gpg: anonymous recipient; trying secret key 69A0DB38 ...
gpg: anonymous recipient; trying secret key D7A9D563 ...
gpg: okay, we are the anonymous recipient.
gpg: Signature made Thu 19 Sep 2013 06:36:05 AM UTC using RSA key ID 69A0DB38
gpg: Good signature from "testing <testing@test.com>"
```

This was discovered when using @joeyh's git-annex with the command like "git annex initremote crypted type=gcrypt gitrepo=~/crypt keyid=477E48E6" but tested manually with gcrypt only and adding gcrypt-participants to the .git/config.
